### PR TITLE
harden: golangci-lint v2 migration and security lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,135 +1,127 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
 output:
   formats:
-    - format: colored-line-number
-  sort-results: true
-
+    text:
+      path: stdout
 linters:
   enable:
-    # バグ検出
     - bodyclose
-    - durationcheck
-    - errcheck
     - copyloopvar
-    - govet
-    - nilerr
-    - noctx
-    - rowserrcheck
-    - sqlclosecheck
-    - staticcheck
-    - typecheck
-
-    # スタイル・可読性
+    - cyclop
+    - durationcheck
     - errname
-    - gofumpt
-    - goimports
+    - gocognit
     - goconst
     - gocritic
-    - gosimple
+    - gosec
     - misspell
     - nakedret
+    - nestif
+    - nilerr
+    - noctx
     - prealloc
     - predeclared
     - revive
-    - stylecheck
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - tparallel
     - unconvert
     - unparam
-    - unused
-    - whitespace
-
-    # セキュリティ
-    - gosec
-
-    # パフォーマンス
-    - ineffassign
-
-    # 複雑度
-    - cyclop
-    - gocognit
-    - nestif
-
-    # テスト
     - usetesting
-    - tparallel
-
-linters-settings:
-  cyclop:
-    max-complexity: 15
-
-  gocognit:
-    min-complexity: 20
-
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-
-  gofumpt:
-    extra-rules: true
-
-  govet:
-    enable-all: true
-
-  nakedret:
-    max-func-lines: 10
-
-  nestif:
-    min-complexity: 5
-
-  revive:
+    - whitespace
+  settings:
+    cyclop:
+      max-complexity: 15
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocognit:
+      min-complexity: 20
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gosec:
+      excludes:
+        - G104
+    govet:
+      enable-all: true
+    nakedret:
+      max-func-lines: 10
+    nestif:
+      min-complexity: 5
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: var-declaration
-      - name: var-naming
-
-  gosec:
-    excludes:
-      - G104  # errcheck がカバー
-
-  stylecheck:
-    checks:
-      - all
-
+      - linters:
+          - errcheck
+          - goconst
+          - gocritic
+          - gosec
+          - noctx
+        path: _test\.go
+      - linters:
+          - noctx
+          - gosec
+        path: testutil/
+      - linters:
+          - cyclop
+          - gocognit
+        path: cmd/
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 50
   max-same-issues: 5
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - goconst
-        - gocritic
-        - errcheck
-        - gosec
-    - path: cmd/
-      linters:
-        - gocognit
-        - cyclop
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/secure-mcp-gateway/main.go
+++ b/cmd/secure-mcp-gateway/main.go
@@ -64,7 +64,8 @@ func run() error {
 
 	// Start gRPC management server.
 	grpcSrv := grpcserver.New(auditStore)
-	grpcLn, err := net.Listen("tcp", cfg.GRPCListenAddr)
+	var lc net.ListenConfig
+	grpcLn, err := lc.Listen(context.Background(), "tcp", cfg.GRPCListenAddr)
 	if err != nil {
 		return err
 	}

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -56,14 +56,15 @@ func NewLoggerWithWriter(w io.Writer, store *Store) *Logger {
 // Log writes an audit entry to both the structured logger and the in-memory store.
 // Sensitive information (tokens, request bodies) is never included.
 func (l *Logger) Log(entry *Entry) {
-	attrs := []slog.Attr{
+	attrs := make([]slog.Attr, 0, 6+len(entry.Metadata))
+	attrs = append(attrs,
 		slog.String("audit_id", entry.ID),
 		slog.String("client_id", entry.ClientID),
 		slog.String("tool_name", entry.ToolName),
 		slog.String("decision", string(entry.Decision)),
 		slog.String("request_id", entry.RequestID),
 		slog.String("timestamp", entry.Timestamp),
-	}
+	)
 
 	for k, v := range entry.Metadata {
 		attrs = append(attrs, slog.String("meta."+k, v))

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -149,8 +150,16 @@ func writeUnauthorized(w http.ResponseWriter, description string) {
 	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="`+description+`"`)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
+
+	resp := struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}{
+		Error:   "unauthorized",
+		Message: description,
+	}
 	//nolint:errcheck // best-effort write to response
-	w.Write([]byte(`{"error":"unauthorized","message":"` + description + `"}`))
+	json.NewEncoder(w).Encode(resp)
 }
 
 // parseScopes splits a space-separated scope string into a slice.

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -97,13 +97,14 @@ func (h *HydraIntrospector) Introspect(ctx context.Context, token string) (*Intr
 	endpoint := h.adminURL + "/admin/oauth2/introspect"
 
 	form := url.Values{"token": {token}}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	// endpoint is derived from the trusted HYDRA_ADMIN_URL server configuration, not user input.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode())) //nolint:gosec // trusted config
 	if err != nil {
 		return nil, fmt.Errorf("failed to create introspection request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := h.httpClient.Do(req)
+	resp, err := h.httpClient.Do(req) //nolint:gosec // trusted config (see above)
 	if err != nil {
 		return nil, fmt.Errorf("introspection request failed: %w", err)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -202,7 +202,9 @@ func (s *Server) forwardRequest(w http.ResponseWriter, r *http.Request, body []b
 		bodyReader = strings.NewReader(string(body))
 	}
 
-	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), bodyReader)
+	// upstream URL is derived from a trusted server-side configuration value (UPSTREAM_MCP_URL),
+	// not from user input. SSRF risk is mitigated by config validation in config.Load().
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), bodyReader) //nolint:gosec // trusted config
 	if err != nil {
 		s.logger.Error("failed to create upstream request", "error", err)
 		s.writeJSONRPCError(w, jsonrpc.CodeInternalError, "internal proxy error")
@@ -212,7 +214,7 @@ func (s *Server) forwardRequest(w http.ResponseWriter, r *http.Request, body []b
 	// Copy relevant headers.
 	copyHeaders(proxyReq.Header, r.Header)
 
-	resp, err := s.httpClient.Do(proxyReq)
+	resp, err := s.httpClient.Do(proxyReq) //nolint:gosec // trusted config (see above)
 	if err != nil {
 		s.logger.Error("upstream request failed", "error", err)
 		s.writeJSONRPCError(w, jsonrpc.CodeInternalError, "upstream server unavailable")
@@ -240,7 +242,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	upstreamURL := s.upstreamURL.JoinPath(r.URL.Path)
 	upstreamURL.RawQuery = r.URL.RawQuery
-	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), r.Body)
+	// upstream URL is derived from trusted server-side configuration (see forwardRequest comment).
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), r.Body) //nolint:gosec // trusted config
 	if err != nil {
 		s.logger.Error("failed to create SSE upstream request", "error", err)
 		http.Error(w, "internal proxy error", http.StatusInternalServerError)
@@ -249,7 +252,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	copyHeaders(proxyReq.Header, r.Header)
 
-	resp, err := s.httpClient.Do(proxyReq)
+	resp, err := s.httpClient.Do(proxyReq) //nolint:gosec // trusted config
 	if err != nil {
 		s.logger.Error("SSE upstream request failed", "error", err)
 		http.Error(w, "upstream server unavailable", http.StatusBadGateway)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -113,12 +113,12 @@ func NewMockHydraServerWithTokenValidation(expectedToken, clientID string) *http
 			return
 		}
 
-		if err := r.ParseForm(); err != nil {
+		if err := r.ParseForm(); err != nil { //nolint:gosec // test mock, no real request body
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
 		}
 
-		token := r.FormValue("token")
+		token := r.FormValue("token") //nolint:gosec // test mock
 		w.Header().Set("Content-Type", "application/json")
 
 		resp := map[string]interface{}{


### PR DESCRIPTION
## Summary
- Migrate `.golangci.yml` to golangci-lint v2 format (fixes `output.formats` config error)
- Fix G705 XSS vulnerability in `writeUnauthorized` by using `json.Encoder` instead of string concatenation
- Suppress G704 SSRF false positives on trusted server-side config URLs with documented `//nolint:gosec`
- Use `net.ListenConfig.Listen` for context-aware gRPC listener (noctx)
- Preallocate `attrs` slice in audit logger (prealloc)
- Add noctx/gosec exclusions for test and testutil paths

## Test plan
- [x] `make check` passes (0 lint issues, all tests green)
- [x] `make quality` passes
- [x] Pre-commit hook (lefthook) passes all gates