### PR TITLE
fix: strip Authorization header from upstream requests

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -318,9 +318,11 @@ func isMaxBytesError(err error) bool {
 	return errors.As(err, &maxBytesErr)
 }
 
-// copyHeaders copies HTTP headers, excluding hop-by-hop headers.
+// copyHeaders copies HTTP headers, excluding hop-by-hop and
+// security-sensitive headers that must not be forwarded to upstream.
 func copyHeaders(dst, src http.Header) {
-	hopByHop := map[string]bool{
+	excluded := map[string]bool{
+		// Hop-by-hop headers (RFC 2616 §13.5.1).
 		"Connection":          true,
 		"Keep-Alive":          true,
 		"Proxy-Authenticate":  true,
@@ -329,10 +331,14 @@ func copyHeaders(dst, src http.Header) {
 		"Trailer":             true,
 		"Transfer-Encoding":   true,
 		"Upgrade":             true,
+		// Security: the Authorization header carries the client's Bearer
+		// token for gateway authentication. Forwarding it to upstream
+		// would leak credentials to an external service.
+		"Authorization": true,
 	}
 
 	for key, values := range src {
-		if hopByHop[key] {
+		if excluded[key] {
 			continue
 		}
 		for _, value := range values {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -537,3 +537,75 @@ func TestProxy_SSEQueryStringForwarding(t *testing.T) {
 	assert.Contains(t, receivedQuery, "cursor=xyz")
 	assert.Contains(t, receivedQuery, "transport=sse")
 }
+
+func TestProxy_AuthorizationHeaderNotForwarded(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuthHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  map[string]interface{}{},
+		})
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	proxyURL, cleanup := newTestProxy(t, upstream.URL)
+	defer cleanup()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, proxyURL+"/",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer super-secret-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, receivedAuthHeader,
+		"Authorization header must not be forwarded to upstream")
+}
+
+func TestProxy_SSEAuthorizationHeaderNotForwarded(t *testing.T) {
+	t.Parallel()
+
+	var receivedAuthHeader string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: {\"event\":\"test\"}\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	proxyURL, cleanup := newTestProxy(t, upstream.URL)
+	defer cleanup()
+
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL+"/sse", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Authorization", "Bearer sse-secret-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, receivedAuthHeader,
+		"Authorization header must not be forwarded to upstream via SSE")
+}


### PR DESCRIPTION
## Summary
- Authorization ヘッダーが `copyHeaders()` により upstream MCP サーバーにそのまま転送されていた脆弱性を修正
- クライアントの Bearer トークンは gateway 認証専用であり、upstream への漏洩は credential leak に該当
- `copyHeaders()` の除外マップに `Authorization` を追加し、forwardRequest / handleSSE 両パスで自動的にストリップ

## Test plan
- [x] `TestProxy_AuthorizationHeaderNotForwarded` — JSON-RPC 転送時に upstream が Authorization を受け取らないことを検証
- [x] `TestProxy_SSEAuthorizationHeaderNotForwarded` — SSE 転送時に upstream が Authorization を受け取らないことを検証
- [x] `make check` 全テスト通過（lint, race detector 含む）