### PR TITLE
fix: enforce body size limit in audit middleware

### DIFF
--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -13,6 +13,11 @@ import (
 // unknownValue is the fallback used when client ID or tool name cannot be determined.
 const unknownValue = "unknown"
 
+// maxRequestSize is the maximum allowed request body size (1MB).
+// This must be enforced before any io.ReadAll to prevent memory
+// exhaustion from oversized payloads.
+const maxRequestSize = 1 << 20
+
 // Middleware provides HTTP middleware for audit logging of MCP tool invocations.
 type Middleware struct {
 	logger    *Logger
@@ -78,6 +83,11 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		// Enforce body size limit before any io.ReadAll to prevent
+		// memory exhaustion. Without this, an attacker could send an
+		// arbitrarily large body that extractToolName would fully buffer.
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 
 		// Read body to extract tool name, then restore it for downstream.
 		toolName := extractToolName(r)

--- a/internal/audit/middleware_test.go
+++ b/internal/audit/middleware_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -229,4 +230,36 @@ func TestAuditMiddleware_BodyPreservedForDownstream(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	assert.Equal(t, "tools/list", receivedMethod)
+}
+
+func TestAuditMiddleware_OversizedBodyRejected(t *testing.T) {
+	t.Parallel()
+
+	mw, _, store := newTestMiddleware(t)
+
+	var downstreamBodySize int
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		downstreamBodySize = len(body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := mw.Handler(inner)
+
+	// 1MB + 1 byte exceeds the maxRequestSize limit.
+	oversizedBody := strings.Repeat("x", 1<<20+1)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(oversizedBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// The MaxBytesReader should prevent the full body from being read.
+	assert.LessOrEqual(t, downstreamBodySize, 1<<20,
+		"downstream should not receive more than 1MB of body data")
+
+	// Audit should still log with unknownValue tool name (body was too large to parse).
+	assert.Equal(t, 1, store.Count())
+	entries, _ := store.List(0, 1)
+	require.Len(t, entries, 1)
+	assert.Equal(t, unknownValue, entries[0].ToolName)
 }


### PR DESCRIPTION
## Summary
- Audit middleware の `extractToolName()` が `io.ReadAll` でリクエストボディを無制限に読み取っていた DoS 脆弱性を修正
- middleware チェーンで audit は proxy の `MaxBytesReader` より先に実行されるため、サイズ制限がバイパスされていた
- `Handler()` の POST 処理冒頭で `http.MaxBytesReader(w, r.Body, 1<<20)` を設定し、`extractToolName` および downstream の全ての読み取りに制限を適用

## Test plan
- [x] `TestAuditMiddleware_OversizedBodyRejected` — 1MB 超のボディが downstream に全量到達しないことを検証
- [x] `TestAuditMiddleware_BodyPreservedForDownstream` — 正常サイズのボディが downstream に正しく渡ることを検証（既存テスト、回帰確認）
- [x] `make check` 全テスト通過（lint, race detector 含む）