### PR TITLE
fix: upgrade golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
@@ -24,7 +24,7 @@ jobs:
         run: |
           go install mvdan.cc/gofumpt@latest
           go install golang.org/x/tools/cmd/goimports@latest
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.1.6
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
 
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1


### PR DESCRIPTION
golangci-lint v2.1.6 is built with Go 1.24 and fails on Go 1.25.0 projects. Upgrade to v2.11.4 which supports Go 1.25. Also fix actions/checkout v6->v4 and setup-go v6->v5 (v6 does not exist).