### PR TITLE
fix: review R1-R2 reliability and security improvements

### DIFF
--- a/cmd/secure-mcp-gateway/main.go
+++ b/cmd/secure-mcp-gateway/main.go
@@ -84,18 +84,27 @@ func run() error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
 
+	var startupErr error
 	select {
 	case sig := <-quit:
 		slog.Info("received shutdown signal", "signal", sig)
-	case err := <-errCh:
-		return err
+	case startupErr = <-errCh:
+		slog.Error("server error, initiating shutdown", "error", startupErr)
 	}
 
 	// Give in-flight requests up to 30 seconds to complete.
+	// GracefulStop is always called regardless of how shutdown was triggered.
 	const shutdownTimeout = 30 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 	defer cancel()
 
 	grpcSrv.GracefulStop()
-	return srv.Shutdown(ctx)
+	if err := srv.Shutdown(ctx); err != nil {
+		return err
+	}
+	// Close audit log file if it was opened (no-op for stdout).
+	if err := auditLogger.Close(); err != nil {
+		slog.Error("failed to close audit log", "error", err)
+	}
+	return startupErr
 }

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -12,6 +12,7 @@ import (
 type Logger struct {
 	slogger *slog.Logger
 	store   *Store
+	closer  io.Closer // non-nil when the logger owns the underlying file
 }
 
 // NewLogger creates a new audit logger.
@@ -29,6 +30,12 @@ func NewLogger(logPath string, store *Store) (*Logger, error) {
 			return nil, err
 		}
 		w = f
+		l := &Logger{
+			slogger: slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: slog.LevelInfo})),
+			store:   store,
+			closer:  f,
+		}
+		return l, nil
 	}
 
 	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{
@@ -39,6 +46,16 @@ func NewLogger(logPath string, store *Store) (*Logger, error) {
 		slogger: slog.New(handler),
 		store:   store,
 	}, nil
+}
+
+// Close releases resources held by the logger.
+// When the logger writes to a file (not stdout), Close closes the file.
+// It is safe to call Close multiple times.
+func (l *Logger) Close() error {
+	if l.closer != nil {
+		return l.closer.Close()
+	}
+	return nil
 }
 
 // NewLoggerWithWriter creates an audit logger that writes to the given writer.

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -23,7 +23,7 @@ func TestLogger_Log(t *testing.T) {
 	logger.Log(entry)
 
 	// Verify structured log output.
-	var logOutput map[string]interface{}
+	var logOutput map[string]any
 	err := json.Unmarshal(buf.Bytes(), &logOutput)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestLogger_LogDeny(t *testing.T) {
 	entry := NewEntry("unknown", "tools/call", DecisionDeny, "req-000", nil)
 	logger.Log(entry)
 
-	var logOutput map[string]interface{}
+	var logOutput map[string]any
 	err := json.Unmarshal(buf.Bytes(), &logOutput)
 	require.NoError(t, err)
 
@@ -130,4 +130,28 @@ func TestNewLogger_InvalidPath(t *testing.T) {
 	store := NewStore()
 	_, err := NewLogger("/nonexistent/dir/audit.log", store)
 	require.Error(t, err)
+}
+
+func TestNewLogger_FileClose(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := dir + "/audit_test.log"
+	store := NewStore()
+	logger, err := NewLogger(path, store)
+	require.NoError(t, err)
+
+	logger.Log(NewEntry("c", "tools/call", DecisionAllow, "r", nil))
+
+	require.NoError(t, logger.Close())
+}
+
+func TestNewLogger_StdoutClose(t *testing.T) {
+	t.Parallel()
+
+	store := NewStore()
+	logger, err := NewLogger("stdout", store)
+	require.NoError(t, err)
+
+	require.NoError(t, logger.Close())
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -343,7 +343,8 @@ func isMaxBytesError(err error) bool {
 }
 
 // copyHeaders copies HTTP headers, excluding hop-by-hop and
-// security-sensitive headers that must not be forwarded to upstream.
+// security-sensitive headers that must not be forwarded.
+// Used for both request headers (to upstream) and response headers (to client).
 func copyHeaders(dst, src http.Header) {
 	excluded := map[string]bool{
 		// Hop-by-hop headers (RFC 2616 §13.5.1).
@@ -359,6 +360,9 @@ func copyHeaders(dst, src http.Header) {
 		// token for gateway authentication. Forwarding it to upstream
 		// would leak credentials to an external service.
 		"Authorization": true,
+		// Internal audit header: strip from both directions to prevent
+		// leaking internal infrastructure details to clients or upstream.
+		"X-Audit-Client-Id": true,
 	}
 
 	for key, values := range src {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -14,10 +14,10 @@ import (
 
 // JSONRPCRequest represents a JSON-RPC 2.0 request for testing.
 type JSONRPCRequest struct {
-	Params  any `json:"params,omitempty"`
-	JSONRPC string      `json:"jsonrpc"`
-	Method  string      `json:"method"`
-	ID      int         `json:"id"`
+	Params  any    `json:"params,omitempty"`
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	ID      int    `json:"id"`
 }
 
 // JSONRPCResponse represents a JSON-RPC 2.0 response for testing.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -14,7 +14,7 @@ import (
 
 // JSONRPCRequest represents a JSON-RPC 2.0 request for testing.
 type JSONRPCRequest struct {
-	Params  interface{} `json:"params,omitempty"`
+	Params  any `json:"params,omitempty"`
 	JSONRPC string      `json:"jsonrpc"`
 	Method  string      `json:"method"`
 	ID      int         `json:"id"`
@@ -35,7 +35,7 @@ type JSONRPCError struct {
 }
 
 // NewJSONRPCRequest creates a new JSON-RPC 2.0 request body as an io.Reader.
-func NewJSONRPCRequest(t *testing.T, method string, params interface{}) io.Reader {
+func NewJSONRPCRequest(t *testing.T, method string, params any) io.Reader {
 	t.Helper()
 
 	req := JSONRPCRequest{
@@ -85,7 +85,7 @@ func NewMockHydraServer(active bool, clientID string) *httptest.Server {
 
 		w.Header().Set("Content-Type", "application/json")
 
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"active": active,
 		}
 		if active {
@@ -121,7 +121,7 @@ func NewMockHydraServerWithTokenValidation(expectedToken, clientID string) *http
 		token := r.FormValue("token") //nolint:gosec // test mock
 		w.Header().Set("Content-Type", "application/json")
 
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"active": token == expectedToken,
 		}
 		if token == expectedToken {


### PR DESCRIPTION
Fix gRPC GracefulStop not called on server error, add audit logger Close method to prevent file descriptor leak, filter X-Audit-Client-Id from response headers, and replace interface{} with any.