### PR TITLE
fix: review R4/R5 - restore partial body in extractToolName on MaxBytesError

### DIFF
--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -179,12 +179,16 @@ func extractToolName(r *http.Request) string {
 		return unknownValue
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
+	body, readErr := io.ReadAll(r.Body)
+	// Always restore whatever was read so downstream handlers can still process or
+	// correctly reject the request. When readErr != nil (e.g., MaxBytesError from
+	// an oversized body), body contains partial data; restoring it ensures the proxy
+	// MaxBytesReader can return the appropriate error response instead of treating
+	// the body as empty.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if readErr != nil {
 		return unknownValue
 	}
-	// Restore body for downstream handlers.
-	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	req, err := jsonrpc.Parse(body)
 	if err != nil {

--- a/internal/audit/middleware_test.go
+++ b/internal/audit/middleware_test.go
@@ -269,3 +269,31 @@ func TestAuditMiddleware_OversizedBodyRejected(t *testing.T) {
 	require.Len(t, entries, 1)
 	assert.Equal(t, unknownValue, entries[0].ToolName)
 }
+
+func TestAuditMiddleware_OversizedBodyRestoredForDownstream(t *testing.T) {
+	t.Parallel()
+
+	mw, _, _ := newTestMiddleware(t)
+
+	var downstreamBodySize int
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		downstreamBodySize = len(body)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := mw.Handler(inner)
+
+	// 1MB + 1 byte: audit middleware reads up to 1MB then fails.
+	// The partial 1MB body must be restored for downstream to read.
+	oversizedBody := strings.Repeat("x", 1<<20+1)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(oversizedBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Downstream should receive the partial body (up to 1MB), not an empty body.
+	// This ensures downstream can generate the correct error response.
+	assert.Equal(t, 1<<20, downstreamBodySize,
+		"partial body must be restored for downstream processing")
+}


### PR DESCRIPTION
## Summary
- **MEDIUM fix**: extractToolName in audit middleware did not restore r.Body when io.ReadAll failed due to MaxBytesReader limit. The partial body was silently discarded, causing downstream proxy to receive an empty body and return a JSON parse error instead of the correct request body exceeds 1MB limit error.
- Fix: always restore whatever was read into r.Body before returning on error, so the proxy MaxBytesReader can detect the overflow and generate the appropriate error response.
- Add TestAuditMiddleware_OversizedBodyRestoredForDownstream to verify partial body is passed to downstream handler.

## Test plan
- go test -race ./internal/audit/... passes including new test
- go test -race ./... full suite passes
- golangci-lint run ./... 0 issues