### PR TITLE
style: apply gofumpt/goimports formatting to unblock CI

### DIFF
--- a/cmd/secure-mcp-gateway/main.go
+++ b/cmd/secure-mcp-gateway/main.go
@@ -36,7 +36,8 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	auditMiddleware := audit.NewMiddleware(auditLogger,
+	auditMiddleware := audit.NewMiddleware(
+		auditLogger,
 		audit.WithSkipPaths("/health"),
 	)
 
@@ -45,7 +46,8 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	authMiddleware := auth.NewMiddleware(introspector,
+	authMiddleware := auth.NewMiddleware(
+		introspector,
 		auth.WithSkipPaths("/health"),
 	)
 
@@ -53,7 +55,8 @@ func run() error {
 	// RequestID -> Audit -> Auth -> Proxy handler
 	// Audit wraps Auth so that both ALLOW and DENY decisions are logged,
 	// ensuring 100% audit log coverage per PRD requirements.
-	srv, err := proxy.New(cfg.ProxyListenAddr, cfg.UpstreamMCPURL,
+	srv, err := proxy.New(
+		cfg.ProxyListenAddr, cfg.UpstreamMCPURL,
 		proxy.WithMiddleware(audit.RequestIDMiddleware),
 		proxy.WithMiddleware(auditMiddleware.Handler),
 		proxy.WithMiddleware(authMiddleware.Handler),

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -74,7 +74,8 @@ func NewLoggerWithWriter(w io.Writer, store *Store) *Logger {
 // Sensitive information (tokens, request bodies) is never included.
 func (l *Logger) Log(entry *Entry) {
 	attrs := make([]slog.Attr, 0, 6+len(entry.Metadata))
-	attrs = append(attrs,
+	attrs = append(
+		attrs,
 		slog.String("audit_id", entry.ID),
 		slog.String("client_id", entry.ClientID),
 		slog.String("tool_name", entry.ToolName),

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -74,7 +74,8 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		// Extract Bearer token from Authorization header.
 		token, err := extractBearerToken(r)
 		if err != nil {
-			m.logger.Warn("token extraction failed",
+			m.logger.Warn(
+				"token extraction failed",
 				"error", err.Error(),
 				"remote_addr", r.RemoteAddr,
 			)
@@ -90,7 +91,8 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 					Scopes:   parseScopes(result.Scope),
 				}
 				ctx := WithTokenInfo(r.Context(), info)
-				m.logger.Debug("token validated from cache",
+				m.logger.Debug(
+					"token validated from cache",
 					"client_id", result.ClientID,
 				)
 				w.Header().Set(auditClientIDHeader, result.ClientID)
@@ -98,7 +100,8 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 				return
 			}
 			// Cached as inactive.
-			m.logger.Warn("token is inactive (cached)",
+			m.logger.Warn(
+				"token is inactive (cached)",
 				"remote_addr", r.RemoteAddr,
 			)
 			writeUnauthorized(w, "token is not active")
@@ -108,7 +111,8 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		// Introspect the token with Hydra.
 		result, err := m.introspector.Introspect(r.Context(), token)
 		if err != nil {
-			m.logger.Error("token introspection failed",
+			m.logger.Error(
+				"token introspection failed",
 				"error", err.Error(),
 				"remote_addr", r.RemoteAddr,
 			)
@@ -120,7 +124,8 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		m.cache.Set(token, result)
 
 		if !result.Active {
-			m.logger.Warn("token is not active",
+			m.logger.Warn(
+				"token is not active",
 				"remote_addr", r.RemoteAddr,
 			)
 			writeUnauthorized(w, "token is not active")
@@ -133,7 +138,8 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 			Scopes:   parseScopes(result.Scope),
 		}
 		ctx := WithTokenInfo(r.Context(), info)
-		m.logger.Info("request authenticated",
+		m.logger.Info(
+			"request authenticated",
 			"client_id", result.ClientID,
 			"remote_addr", r.RemoteAddr,
 		)

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -52,7 +52,8 @@ func TestMiddleware_ValidToken(t *testing.T) {
 		},
 	}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -77,7 +78,8 @@ func TestMiddleware_InvalidToken(t *testing.T) {
 		},
 	}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -98,7 +100,8 @@ func TestMiddleware_MissingToken(t *testing.T) {
 
 	mock := &mockIntrospector{}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -120,7 +123,8 @@ func TestMiddleware_IntrospectionError(t *testing.T) {
 		err: errors.New("hydra is down"),
 	}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -140,7 +144,8 @@ func TestMiddleware_SkipPath(t *testing.T) {
 
 	mock := &mockIntrospector{}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 		WithSkipPaths("/health"),
 	)
@@ -168,7 +173,8 @@ func TestMiddleware_CacheHit(t *testing.T) {
 		},
 	}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -203,7 +209,8 @@ func TestMiddleware_CachedInactiveToken(t *testing.T) {
 		},
 	}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -233,7 +240,8 @@ func TestMiddleware_MultipleSkipPaths(t *testing.T) {
 
 	mock := &mockIntrospector{}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 		WithSkipPaths("/health", "/ready", "/metrics"),
 	)
@@ -256,7 +264,8 @@ func TestMiddleware_NonBearerScheme(t *testing.T) {
 
 	mock := &mockIntrospector{}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -282,7 +291,8 @@ func TestMiddleware_TokenInfoPropagated(t *testing.T) {
 		},
 	}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 	)
 
@@ -315,7 +325,8 @@ func TestMiddleware_WithCustomCache(t *testing.T) {
 
 	mock := &mockIntrospector{}
 
-	mw := NewMiddleware(mock,
+	mw := NewMiddleware(
+		mock,
 		WithMiddlewareLogger(newTestLogger()),
 		WithCache(cache),
 	)

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -31,7 +31,8 @@ func newTestServer(t *testing.T, store *audit.Store) (gatewayv1.GatewayServiceCl
 		_ = srv.Serve(ln)
 	}()
 
-	conn, err := grpc.NewClient(ln.Addr().String(),
+	conn, err := grpc.NewClient(
+		ln.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	require.NoError(t, err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -111,7 +111,8 @@ func New(listenAddr, upstreamMCPURL string, opts ...Option) (*Server, error) {
 
 // ListenAndServe starts the proxy server. It blocks until the server stops.
 func (s *Server) ListenAndServe() error {
-	s.logger.Info("proxy server starting",
+	s.logger.Info(
+		"proxy server starting",
 		"addr", s.httpServer.Addr,
 		"upstream", s.upstreamURL.String(),
 	)
@@ -123,7 +124,8 @@ func (s *Server) ListenAndServe() error {
 
 // Serve starts the proxy server on the given listener. Useful for testing.
 func (s *Server) Serve(ln net.Listener) error {
-	s.logger.Info("proxy server starting",
+	s.logger.Info(
+		"proxy server starting",
 		"addr", ln.Addr().String(),
 		"upstream", s.upstreamURL.String(),
 	)
@@ -206,7 +208,8 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		s.logger.Info("proxying MCP request",
+		s.logger.Info(
+			"proxying MCP request",
 			"method", req.Method,
 			"remote_addr", r.RemoteAddr,
 		)

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -45,14 +45,16 @@ func newTestGateway(
 	auditStore := audit.NewStore()
 	var auditBuf bytes.Buffer
 	auditLogger := audit.NewLoggerWithWriter(&auditBuf, auditStore)
-	auditMiddleware := audit.NewMiddleware(auditLogger,
+	auditMiddleware := audit.NewMiddleware(
+		auditLogger,
 		audit.WithSkipPaths("/health"),
 	)
 
 	// Set up auth middleware using mock Hydra.
 	introspector, err := auth.NewHydraIntrospector(hydraServer.URL, nil)
 	require.NoError(t, err)
-	authMiddleware := auth.NewMiddleware(introspector,
+	authMiddleware := auth.NewMiddleware(
+		introspector,
 		auth.WithSkipPaths("/health"),
 		auth.WithMiddlewareLogger(slog.New(slog.NewJSONHandler(io.Discard, nil))),
 	)
@@ -62,7 +64,8 @@ func newTestGateway(
 	//   RequestID -> Audit -> Auth -> Proxy handler
 	// Audit wraps Auth so that both ALLOW and DENY decisions are logged.
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
-	srv, err := proxy.New(":0", upstreamServer.URL,
+	srv, err := proxy.New(
+		":0", upstreamServer.URL,
 		proxy.WithLogger(logger),
 		proxy.WithMiddleware(audit.RequestIDMiddleware),
 		proxy.WithMiddleware(auditMiddleware.Handler),


### PR DESCRIPTION
## 背景
CI (`ci.yml`) は `gofumpt@latest` / `goimports@latest` をバージョン未固定でインストールし、`make format` 後の `git diff --exit-code` でフォーマット差分を検査する。gofumpt の新バージョンが複数行の logger 呼び出し（第1引数を独立行へ）を整形するルールを追加したため、main の既存コードが未整形と判定され、**全 dependabot PR の `check` ジョブが失敗**していた（例: #32）。

## 変更
`make format`（gofumpt -w + goimports -w）を適用。フォーマットのみでロジック変更なし。7 ファイル。

## 効果
- #29 (fetch-metadata 2→3)、#32 (checkout 4→7) の format-check gate を解除
- 今後の PR も同 gate を通過

## 補足（恒久対応の推奨）
`gofumpt@latest` / `goimports@latest` の未固定はドリフトの再発要因。将来的にバージョン固定を推奨（本PRのスコープ外）。