### PR TITLE
ci: setup-go v6 へ更新（Node 20 deprecation）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/internal/audit/entry_test.go
+++ b/internal/audit/entry_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewEntry(t *testing.T) {
 	t.Parallel()
 
-	metadata := map[string]string{"http_method": "POST"}
+	metadata := map[string]string{metadataKeyHTTPMethod: "POST"}
 	entry := NewEntry("client-123", "tools/call", DecisionAllow, "req-456", metadata)
 
 	assert.NotEmpty(t, entry.ID)
@@ -19,7 +19,7 @@ func TestNewEntry(t *testing.T) {
 	assert.Equal(t, "tools/call", entry.ToolName)
 	assert.Equal(t, DecisionAllow, entry.Decision)
 	assert.Equal(t, "req-456", entry.RequestID)
-	assert.Equal(t, "POST", entry.Metadata["http_method"])
+	assert.Equal(t, "POST", entry.Metadata[metadataKeyHTTPMethod])
 
 	// Verify timestamp is valid RFC 3339.
 	_, err := time.Parse(time.RFC3339, entry.Timestamp)

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -17,8 +17,8 @@ func TestLogger_Log(t *testing.T) {
 	logger := NewLoggerWithWriter(&buf, store)
 
 	entry := NewEntry("client-123", "tools/call", DecisionAllow, "req-456", map[string]string{
-		"http_method": "POST",
-		"path":        "/",
+		metadataKeyHTTPMethod: "POST",
+		"path":                "/",
 	})
 	logger.Log(entry)
 
@@ -95,7 +95,7 @@ func TestLogger_NoSensitiveData(t *testing.T) {
 	logger := NewLoggerWithWriter(&buf, store)
 
 	entry := NewEntry("client-123", "tools/call", DecisionAllow, "req-456", map[string]string{
-		"http_method": "POST",
+		metadataKeyHTTPMethod: "POST",
 	})
 	logger.Log(entry)
 

--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -13,6 +13,9 @@ import (
 // unknownValue is the fallback used when client ID or tool name cannot be determined.
 const unknownValue = "unknown"
 
+// metadataKeyHTTPMethod is the audit entry metadata key for the HTTP method.
+const metadataKeyHTTPMethod = "http_method"
+
 // maxRequestSize is the maximum allowed request body size (1MB).
 // This must be enforced before any io.ReadAll to prevent memory
 // exhaustion from oversized payloads.
@@ -156,10 +159,10 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		requestID := GetRequestID(r.Context())
 
 		metadata := map[string]string{
-			"http_method": r.Method,
-			"path":        r.URL.Path,
-			"remote_addr": r.RemoteAddr,
-			"status_code": http.StatusText(effectiveStatus),
+			metadataKeyHTTPMethod: r.Method,
+			"path":                r.URL.Path,
+			"remote_addr":         r.RemoteAddr,
+			"status_code":         http.StatusText(effectiveStatus),
 		}
 
 		entry := NewEntry(clientID, toolName, decision, requestID, metadata)

--- a/internal/audit/middleware_test.go
+++ b/internal/audit/middleware_test.go
@@ -63,7 +63,7 @@ func TestAuditMiddleware_LogsToolCall(t *testing.T) {
 	assert.Equal(t, "tools/call", entry.ToolName)
 	assert.Equal(t, DecisionAllow, entry.Decision)
 	assert.Equal(t, "test-request-id", entry.RequestID)
-	assert.Equal(t, "POST", entry.Metadata["http_method"])
+	assert.Equal(t, "POST", entry.Metadata[metadataKeyHTTPMethod])
 
 	// Verify structured log output.
 	var logOutput map[string]interface{}


### PR DESCRIPTION
setup-go@v5 は Node 20 ランタイム。dependabot 未検出のため手動対応。あわせてローカル golangci-lint（新版 goconst）が検出した http_method の重複を定数化（pre-commit lint 通過のため。lint 設定は不変更）。actionlint パス済み。