### PR TITLE
feat: OPAによるツール粒度の認可ポリシー評価を実装 (Phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@
 HYDRA_ADMIN_URL=http://localhost:4445
 
 # --- OPA (Open Policy Agent) ---
-# OPA_URL=http://localhost:8181  # Phase 2: OPA policy engine
+# Policy evaluation endpoint (tool-level authorization, fail-close).
+OPA_URL=http://localhost:8181
 
 # --- Proxy ---
 # Upstream MCP server to proxy requests to.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Policy test
+        run: make policy-test
+
       - name: Build
         run: make build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.1.0 (2026-07-19)
+
+### Tool-level Authorization (Phase 2)
+
+- feat: OPAによるツール粒度の認可ポリシー評価を実装（ADR-003のPhase 2対応）
+  - `internal/policy`: OPAクライアント（`/v1/data/gateway/authz/allow`）とポリシー評価ミドルウェアを追加
+  - ミドルウェアチェーンを RequestID → Audit → Auth → Policy → Proxy に拡張。ポリシー拒否は403で監査ログにDENY記録
+  - fail-close: OPA到達不能・非200応答・decision未定義時はデフォルト拒否（fail-openにしない）
+  - `OPA_URL` 環境変数を必須設定として再導入
+- feat: `policies/default.rego` をクライアントID×ツール名の許可制御に整備、許可リストを `policies/data.json` に分離（`"*"` ワイルドカード対応）
+- test: Regoポリシーのユニットテスト（`policies/default_test.rego`）と `make policy-test` を追加、CIに組込み
+- docs: README / CLAUDE.md / ADR-003（Superseded）を実装済みの記述に更新
+
 ## v1.0.0 (2026-04-01)
 
 ### Initial Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## 概要
 
-企業内MCPサーバーの手前でOAuth2認証と監査ログを提供するModel Context Protocol (MCP) ゲートウェイ。ツール単位の認可は未実装でPhase 2の対象。ReBACは将来必要になった場合に再検討する。
+企業内MCPサーバーの手前でOAuth2認証・OPAによるツール粒度の認可・監査ログを提供するModel Context Protocol (MCP) ゲートウェイ。ReBACは将来必要になった場合に再検討する。
 
-## 重要: MVP制限事項
+## セキュリティ方針
 
-- **ポリシー評価は未実装**: OPAによるツール粒度の認可はPhase 2で対応予定。認証済みユーザーは全ツールにアクセス可能。詳細は [ADR-003](docs/adr/0003-mvp-opa-deferred.md) を参照。
+- **ポリシー評価はfail-close**: OPA到達不能・ポリシー未ロード時は403でデフォルト拒否。fail-openにしない
+- ポリシーは `policies/default.rego` + `policies/data.json`（クライアントID×ツール名の許可リスト）。経緯は [ADR-003](docs/adr/0003-mvp-opa-deferred.md)（Superseded）を参照
 
 ## 技術スタック
 
@@ -14,56 +15,32 @@
 - TypeScript MCP SDK — MCPプロトコル処理（サイドカー）
 - gRPC / Protocol Buffers — 内部サービス間通信
 - ORY Hydra — OAuth2/OIDC認証基盤
-- OPA (Open Policy Agent) — ポリシーエンジン（Phase 2で統合予定）
+- OPA (Open Policy Agent) — ポリシーエンジン（ツール粒度認可）
 
 ## コーディングルール
 
 - Go: 標準の Go スタイルガイドに従うこと。golangci-lint + gofumpt を使用
-- Proto/gRPC: `~/.claude/rules/proto.md` のルールに従うこと
-  - フィールド番号の再利用禁止。削除時は `reserved` で予約
-  - `buf lint` / `buf breaking` / `buf format -w` を編集後に実行
+- Proto/gRPC: `~/.claude/rules/proto.md` のルールに従うこと（フィールド番号再利用禁止・削除時は `reserved`。編集後に `buf lint` / `buf breaking` / `buf format -w`）
 
 ## ビルド & テスト
 
 ```bash
-# 全チェック（lint → test → build）
-make check
-
-# 個別実行
-make build        # Go バイナリビルド
-make test         # テスト実行（race detector 有効）
-make lint         # golangci-lint
-make format       # gofumpt + goimports
-
-# 品質チェック（Ship前）
-make quality
+make check        # 全チェック（format → tidy → lint → test → build）
+make test         # Goテスト（race detector 有効）
+make policy-test  # Regoポリシーテスト（Docker）
+make quality      # 品質チェック（Ship前）
 ```
 
 ## ディレクトリ構造
 
 ```
 cmd/secure-mcp-gateway/   -- エントリポイント
-internal/                  -- 内部パッケージ（プロキシ、認可、監査ログ）
-pkg/                       -- 外部公開パッケージ
+internal/                  -- 内部パッケージ（プロキシ、認証、ポリシー、監査ログ）
+policies/                  -- OPA Regoポリシー + 許可リスト（data.json）
 proto/gateway/v1/          -- gRPC / Proto定義
-test/contract/             -- 契約テスト
 docs/                      -- ドキュメント（ADR、品質チェックリスト）
-.github/                   -- CI/CD、Issue/PRテンプレート
 ```
 
 ## 環境変数
 
-```bash
-# ORY Hydra
-HYDRA_ADMIN_URL=          # ORY Hydra Admin API URL（必須）
-
-# プロキシ
-UPSTREAM_MCP_URL=         # 上流MCPサーバーURL（必須）
-PROXY_LISTEN_ADDR=        # リッスンアドレス（デフォルト: :8080）
-
-# 監査ログ
-AUDIT_LOG_PATH=           # 監査ログ出力先（デフォルト: stdout）
-
-# gRPC
-GRPC_LISTEN_ADDR=         # gRPCリッスンアドレス（デフォルト: :9090）
-```
+必須: `HYDRA_ADMIN_URL` / `OPA_URL` / `UPSTREAM_MCP_URL`。任意（デフォルトあり）: `PROXY_LISTEN_ADDR` / `AUDIT_LOG_PATH` / `GRPC_LISTEN_ADDR`。詳細は [README](README.md#environment-variables) と `.env.example` を参照。

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint format check quality clean tidy
+.PHONY: build test policy-test lint format check quality clean tidy
 
 # Go build settings
 GOFLAGS ?= -trimpath
@@ -9,6 +9,10 @@ build:
 
 test:
 	go test -v -race -count=1 -coverprofile=coverage.out ./...
+
+# Rego policy unit tests (requires Docker; uses the same OPA image as docker-compose).
+policy-test:
+	docker run --rm -v $(CURDIR)/policies:/policies:ro openpolicyagent/opa:latest test /policies -v
 
 lint:
 	golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # secure-mcp-gateway
 
-> **NOTE: MVP — ポリシー評価は未実装。認証済みユーザーは全ツールにアクセス可能。** OPAによるツール粒度の認可はPhase 2で対応予定。詳細は [ADR-003](docs/adr/0003-mvp-opa-deferred.md) を参照。
-
-企業内MCPサーバーの手前でOAuth2認証と監査ログを提供するModel Context Protocol (MCP) ゲートウェイ。現在のMVPは認証境界までを実装しており、ツール単位の認可は未実装です。
+企業内MCPサーバーの手前でOAuth2認証・OPAによるツール粒度の認可・監査ログを提供するModel Context Protocol (MCP) ゲートウェイ。ポリシー評価はfail-close（OPA障害時はデフォルト拒否）で動作します。
 
 ## Features
 
 - **MCP Proxy**: MCP over HTTP/SSE リクエストの透過的な中継
 - **OAuth2 Token Validation**: ORY Hydra 連携による Bearer トークン検証
-- **Tool-level Authorization (未実装)**: OPA によるツール呼び出し粒度の認可ポリシーはPhase 2で実装予定
-- **Audit Logging**: 全アクセスの構造化ログ出力
+- **Tool-level Authorization**: OPA によるツール呼び出し粒度の認可ポリシー評価（fail-close: OPA到達不能時はデフォルト拒否）
+- **Audit Logging**: 全アクセスの構造化ログ出力（ALLOW/DENY 両方を記録）
 
 ## Architecture
 
 ```
 [AI Agent] → [secure-mcp-gateway] → [MCP Server] → [Data Sources]
                     ├── Token Validation (ORY Hydra)
-                    ├── Policy Evaluation (OPA, Phase 2)
+                    ├── Policy Evaluation (OPA)
                     └── Audit Logging
 ```
 
@@ -25,7 +23,7 @@
 - Go (proxy layer, ORY Go SDK)
 - gRPC / Protocol Buffers (internal communication)
 - ORY Hydra (OAuth2/OIDC)
-- OPA (policy engine, Phase 2で統合予定)
+- OPA (policy engine)
 
 ## Quick Start
 
@@ -45,7 +43,7 @@ cp .env.example .env
 
 ### 2. Start Dependencies
 
-Docker Compose starts ORY Hydra (OAuth2), the future policy integration used for local development (OPA), and a mock MCP server. The gateway does not call OPA in the current MVP:
+Docker Compose starts ORY Hydra (OAuth2), OPA (policy engine), and a mock MCP server:
 
 ```bash
 docker compose up -d
@@ -59,7 +57,7 @@ docker compose ps
 |---------|------|---------|
 | ORY Hydra (Public) | `4444` | OAuth2 token endpoint |
 | ORY Hydra (Admin) | `4445` | Token introspection |
-| OPA | `8181` | Phase 2向けのローカル開発依存（MVPからは未使用） |
+| OPA | `8181` | Policy evaluation (tool-level authorization) |
 | Mock MCP Server | `3001` | Upstream MCP (dev only) |
 
 ### 3. Build & Run
@@ -96,21 +94,63 @@ curl -s -X POST http://localhost:8080/ \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq
 ```
 
-### 5. Run Tests
+### 5. Try Tool-level Authorization
+
+ツール呼び出し（`tools/call`）はOPAポリシーで許可されたクライアント×ツールの組み合わせのみ通過します。許可リストは [`policies/data.json`](policies/data.json) で管理します:
+
+```json
+{
+  "gateway": {
+    "permissions": {
+      "demo-agent": ["mock-tool"]
+    }
+  }
+}
+```
+
+```bash
+# 許可されたツール（data.jsonでclient_idに付与済み）→ 200 OK
+curl -s -X POST http://localhost:8080/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"mock-tool"}}' | jq
+
+# 許可されていないツール → 403 Forbidden ("denied by policy")
+curl -s -X POST http://localhost:8080/ \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"secret-tool"}}' | jq
+```
+
+ポリシーの変更は `policies/` のRego/JSONを編集してOPAを再起動（`docker compose restart opa`）するだけで反映され、ゲートウェイの再デプロイは不要です。
+
+### 6. Run Tests
 
 ```bash
 # Unit + integration tests with race detector
 make test
 
+# Rego policy unit tests (Docker)
+make policy-test
+
 # Full check (format -> tidy -> lint -> test -> build)
 make check
 ```
+
+## Policy Configuration
+
+- [`policies/default.rego`](policies/default.rego) — 認可ルール本体。デフォルト拒否で、`initialize` / `tools/list` などのディスカバリ系メソッドは認証済みクライアントに許可、`tools/call` は `data.json` の許可リストに一致した場合のみ許可
+- [`policies/data.json`](policies/data.json) — クライアントID→許可ツール名のマッピング。`"*"` で全ツール許可
+- [`policies/default_test.rego`](policies/default_test.rego) — ポリシーのユニットテスト（`make policy-test`）
+
+**Fail-close**: OPAが停止・到達不能・ポリシー未ロードの場合、ゲートウェイは全リクエストを `403 Forbidden` で拒否します。セキュリティゲートウェイとしてfail-openにはなりません。
 
 ## Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `HYDRA_ADMIN_URL` | Yes | - | ORY Hydra Admin API URL |
+| `OPA_URL` | Yes | - | OPA server base URL for policy evaluation |
 | `UPSTREAM_MCP_URL` | Yes | - | Upstream MCP server URL |
 | `PROXY_LISTEN_ADDR` | No | `:8080` | HTTP proxy listen address |
 | `AUDIT_LOG_PATH` | No | `stdout` | Audit log output path (file path or `stdout`) |
@@ -124,7 +164,7 @@ Key design decisions are documented in [`docs/adr/`](docs/adr/):
 
 - [ADR-001: MCP Transport Layer](docs/adr/0001-mcp-transport-layer.md) — HTTP/SSE を採用した理由
 - [ADR-002: Policy Engine](docs/adr/0002-policy-engine-opa.md) — OPA を採用した理由
-- [ADR-003: MVP OPA Deferred](docs/adr/0003-mvp-opa-deferred.md) — MVPではOPAポリシー評価を未実装とする決定
+- [ADR-003: MVP OPA Deferred](docs/adr/0003-mvp-opa-deferred.md) — MVPではOPAポリシー評価を未実装とした決定（Superseded: Phase 2で実装済み）
 
 ## Development
 

--- a/cmd/secure-mcp-gateway/main.go
+++ b/cmd/secure-mcp-gateway/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/akaitigo/secure-mcp-gateway/internal/auth"
 	"github.com/akaitigo/secure-mcp-gateway/internal/config"
 	"github.com/akaitigo/secure-mcp-gateway/internal/grpcserver"
+	"github.com/akaitigo/secure-mcp-gateway/internal/policy"
 	"github.com/akaitigo/secure-mcp-gateway/internal/proxy"
 )
 
@@ -51,15 +52,29 @@ func run() error {
 		auth.WithSkipPaths("/health"),
 	)
 
+	// Set up OPA policy evaluation middleware (fail-close: requests are
+	// denied when the policy engine is unreachable).
+	policyClient, err := policy.NewClient(cfg.OPAURL, nil)
+	if err != nil {
+		return err
+	}
+	policyMiddleware := policy.NewMiddleware(
+		policyClient,
+		policy.WithSkipPaths("/health"),
+	)
+
 	// Build proxy with middleware chain:
-	// RequestID -> Audit -> Auth -> Proxy handler
-	// Audit wraps Auth so that both ALLOW and DENY decisions are logged,
-	// ensuring 100% audit log coverage per PRD requirements.
+	// RequestID -> Audit -> Auth -> Policy -> Proxy handler
+	// Audit wraps Auth and Policy so that both ALLOW and DENY decisions are
+	// logged, ensuring 100% audit log coverage per PRD requirements.
+	// Policy runs after Auth because it needs the authenticated client
+	// identity from the request context.
 	srv, err := proxy.New(
 		cfg.ProxyListenAddr, cfg.UpstreamMCPURL,
 		proxy.WithMiddleware(audit.RequestIDMiddleware),
 		proxy.WithMiddleware(auditMiddleware.Handler),
 		proxy.WithMiddleware(authMiddleware.Handler),
+		proxy.WithMiddleware(policyMiddleware.Handler),
 	)
 	if err != nil {
 		return err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,13 +22,18 @@ services:
       retries: 5
 
   # OPA - Open Policy Agent
+  # The -debug variant ships busybox so the wget healthcheck can run
+  # (the default image is distroless and has no shell/wget).
   opa:
-    image: openpolicyagent/opa:latest
+    image: openpolicyagent/opa:latest-debug
     ports:
       - "8181:8181"
     command:
       - run
       - --server
+      # Bind to all interfaces; the default (localhost) is unreachable
+      # through the published port from the host.
+      - --addr=0.0.0.0:8181
       - --log-level=info
       - --set=decision_logs.console=true
       - /policies
@@ -36,7 +41,7 @@ services:
       - ./policies:/policies:ro
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:8181/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8181/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/adr/0003-mvp-opa-deferred.md
+++ b/docs/adr/0003-mvp-opa-deferred.md
@@ -1,7 +1,9 @@
 # ADR-003: MVPではOPAポリシー評価を未実装とする
 
 ## ステータス
-承認
+Superseded（2026-07-19: Phase 2でOPAポリシー評価を実装済み）
+
+本ADRの決定は役割を終えた。`OPA_URL` 設定と `internal/policy` ミドルウェア（fail-close）が導入され、認証済みクライアントであってもポリシーで許可されていないツールは呼び出せない。
 
 ## コンテキスト
 ADR-002でOPAをポリシーエンジンとして採用する決定を行ったが、MVP時点では以下の状況にある:
@@ -27,3 +29,10 @@ MVP（Phase 1）ではOPAポリシー評価を実装せず、Phase 2で対応す
 - 認証済みクライアントは全MCPツールにアクセス可能（MVP制限事項）
 - Phase 2で `OPA_URL` 設定とポリシー評価ミドルウェアを追加する
 - Phase 2着手時は本ADRのステータスを「Phase 2で置換」に更新する
+
+## 追記（2026-07-19: Phase 2実装完了）
+Phase 2の実装が完了し、本ADRはSupersededとなった:
+1. `config.go` に `OPA_URL`（必須）を再導入
+2. `internal/policy` パッケージでOPAクライアントとポリシー評価ミドルウェアを実装（ミドルウェア順: RequestID → Audit → Auth → Policy → Proxy）
+3. OPA到達不能・ポリシー未ロード時はfail-close（403でデフォルト拒否）。fail-openにはしない
+4. `policies/default.rego` + `policies/data.json` でクライアント×ツール名のallow/deny制御（PRDの「MVPでは単純なallow/denyポリシーに限定」の方針を踏襲）

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	ProxyListenAddr string
 	// HydraAdminURL is the ORY Hydra Admin API URL for token introspection.
 	HydraAdminURL string
+	// OPAURL is the OPA server base URL for tool-level policy evaluation.
+	OPAURL string
 	// AuditLogPath is the output path for audit logs ("stdout" or a file path).
 	AuditLogPath string
 	// GRPCListenAddr is the address for the gRPC management API to listen on.
@@ -28,6 +30,7 @@ func Load() (*Config, error) {
 		UpstreamMCPURL:  os.Getenv("UPSTREAM_MCP_URL"),
 		ProxyListenAddr: envOrDefault("PROXY_LISTEN_ADDR", ":8080"),
 		HydraAdminURL:   os.Getenv("HYDRA_ADMIN_URL"),
+		OPAURL:          os.Getenv("OPA_URL"),
 		AuditLogPath:    envOrDefault("AUDIT_LOG_PATH", "stdout"),
 		GRPCListenAddr:  envOrDefault("GRPC_LISTEN_ADDR", ":9090"),
 	}
@@ -54,6 +57,14 @@ func (c *Config) validate() error {
 
 	if _, err := url.ParseRequestURI(c.HydraAdminURL); err != nil {
 		return fmt.Errorf("HYDRA_ADMIN_URL is not a valid URL: %w", err)
+	}
+
+	if c.OPAURL == "" {
+		return errors.New("OPA_URL is required")
+	}
+
+	if _, err := url.ParseRequestURI(c.OPAURL); err != nil {
+		return fmt.Errorf("OPA_URL is not a valid URL: %w", err)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,7 @@ func TestLoad_Success(t *testing.T) {
 	t.Setenv("UPSTREAM_MCP_URL", "http://localhost:3001")
 	t.Setenv("PROXY_LISTEN_ADDR", ":9090")
 	t.Setenv("HYDRA_ADMIN_URL", "http://localhost:4445")
+	t.Setenv("OPA_URL", "http://localhost:8181")
 	t.Setenv("AUDIT_LOG_PATH", "/var/log/audit.log")
 	t.Setenv("GRPC_LISTEN_ADDR", ":50051")
 
@@ -22,6 +23,7 @@ func TestLoad_Success(t *testing.T) {
 	assert.Equal(t, "http://localhost:3001", cfg.UpstreamMCPURL)
 	assert.Equal(t, ":9090", cfg.ProxyListenAddr)
 	assert.Equal(t, "http://localhost:4445", cfg.HydraAdminURL)
+	assert.Equal(t, "http://localhost:8181", cfg.OPAURL)
 	assert.Equal(t, "/var/log/audit.log", cfg.AuditLogPath)
 	assert.Equal(t, ":50051", cfg.GRPCListenAddr)
 }
@@ -29,6 +31,7 @@ func TestLoad_Success(t *testing.T) {
 func TestLoad_Defaults(t *testing.T) {
 	t.Setenv("UPSTREAM_MCP_URL", "http://localhost:3001")
 	t.Setenv("HYDRA_ADMIN_URL", "http://localhost:4445")
+	t.Setenv("OPA_URL", "http://localhost:8181")
 	// Clear optional env vars to test defaults.
 	t.Setenv("PROXY_LISTEN_ADDR", "")
 	t.Setenv("AUDIT_LOG_PATH", "")
@@ -74,4 +77,24 @@ func TestLoad_InvalidHydraAdminURL(t *testing.T) {
 	_, err := config.Load()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HYDRA_ADMIN_URL is not a valid URL")
+}
+
+func TestLoad_MissingOPAURL(t *testing.T) {
+	t.Setenv("UPSTREAM_MCP_URL", "http://localhost:3001")
+	t.Setenv("HYDRA_ADMIN_URL", "http://localhost:4445")
+	t.Setenv("OPA_URL", "")
+
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OPA_URL is required")
+}
+
+func TestLoad_InvalidOPAURL(t *testing.T) {
+	t.Setenv("UPSTREAM_MCP_URL", "http://localhost:3001")
+	t.Setenv("HYDRA_ADMIN_URL", "http://localhost:4445")
+	t.Setenv("OPA_URL", "not-a-valid-url")
+
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OPA_URL is not a valid URL")
 }

--- a/internal/policy/middleware.go
+++ b/internal/policy/middleware.go
@@ -1,0 +1,229 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/akaitigo/secure-mcp-gateway/internal/auth"
+	"github.com/akaitigo/secure-mcp-gateway/internal/jsonrpc"
+)
+
+// maxRequestSize is the maximum allowed request body size (1MB).
+// This mirrors the limit enforced by the proxy and audit middleware.
+const maxRequestSize = 1 << 20
+
+// toolCallMethod is the JSON-RPC method for MCP tool invocations.
+const toolCallMethod = "tools/call"
+
+// Middleware provides HTTP middleware that enforces OPA policy decisions
+// for MCP tool invocations. It must run after the auth middleware so that
+// the authenticated client identity is available in the request context.
+//
+// Failure semantics are fail-close: when the policy engine is unreachable
+// or returns an unexpected response, the request is denied with 403.
+type Middleware struct {
+	evaluator Evaluator
+	logger    *slog.Logger
+	skipPaths map[string]bool
+}
+
+// MiddlewareOption configures the policy Middleware.
+type MiddlewareOption func(*Middleware)
+
+// WithMiddlewareLogger sets a custom logger for the middleware.
+func WithMiddlewareLogger(logger *slog.Logger) MiddlewareOption {
+	return func(m *Middleware) {
+		m.logger = logger
+	}
+}
+
+// WithSkipPaths sets paths that bypass policy evaluation (e.g., "/health").
+func WithSkipPaths(paths ...string) MiddlewareOption {
+	return func(m *Middleware) {
+		for _, p := range paths {
+			m.skipPaths[p] = true
+		}
+	}
+}
+
+// NewMiddleware creates a new policy middleware with the given evaluator.
+func NewMiddleware(evaluator Evaluator, opts ...MiddlewareOption) *Middleware {
+	m := &Middleware{
+		evaluator: evaluator,
+		logger:    slog.Default(),
+		skipPaths: make(map[string]bool),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// Handler wraps the given handler with OPA policy enforcement.
+//
+// Only JSON-RPC POST requests carry tool invocations and are evaluated.
+// Non-POST requests (e.g., GET for SSE stream setup) do not invoke tools
+// and pass through; they have already passed token verification.
+// Malformed JSON-RPC bodies pass through so the proxy handler can return
+// the proper JSON-RPC error response without forwarding upstream.
+func (m *Middleware) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip policy evaluation for configured paths.
+		if m.skipPaths[r.URL.Path] {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		input, proceed := m.buildInput(w, r)
+		if input == nil {
+			if proceed {
+				next.ServeHTTP(w, r)
+			}
+			return
+		}
+
+		allowed, err := m.evaluator.Evaluate(r.Context(), input)
+		if err != nil {
+			// Fail-close: deny when the policy engine is unreachable or
+			// returns an unexpected response. A security gateway must never
+			// fail open.
+			m.logger.Error(
+				"policy evaluation failed, denying request (fail-close)",
+				"error", err.Error(),
+				"client_id", input.ClientID,
+				"method", input.Method,
+				"tool_name", input.ToolName,
+				"remote_addr", r.RemoteAddr,
+			)
+			writeForbidden(w, "policy evaluation unavailable")
+			return
+		}
+
+		if !allowed {
+			m.logger.Warn(
+				"request denied by policy",
+				"client_id", input.ClientID,
+				"method", input.Method,
+				"tool_name", input.ToolName,
+				"remote_addr", r.RemoteAddr,
+			)
+			writeForbidden(w, "denied by policy")
+			return
+		}
+
+		m.logger.Debug(
+			"request allowed by policy",
+			"client_id", input.ClientID,
+			"method", input.Method,
+			"tool_name", input.ToolName,
+		)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// buildInput parses the JSON-RPC request body and builds the policy input.
+// It returns (nil, true) when the request should pass through to the next
+// handler without policy evaluation (non-JSON or malformed bodies that the
+// proxy handler will reject itself), and (input, false) when evaluation is
+// required. An empty body yields an input with an empty method, which the
+// default-deny policy rejects, so bodyless POSTs cannot bypass evaluation.
+func (m *Middleware) buildInput(w http.ResponseWriter, r *http.Request) (*Input, bool) {
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		// The proxy handler rejects non-JSON POSTs with a JSON-RPC error.
+		return nil, true
+	}
+
+	body, ok := m.readBody(w, r)
+	if !ok {
+		// Oversized body: the proxy handler returns the size-limit error.
+		return nil, true
+	}
+
+	input := &Input{}
+	if info := auth.GetTokenInfo(r.Context()); info != nil {
+		input.ClientID = info.ClientID
+		input.Scopes = info.Scopes
+	}
+
+	if len(body) == 0 {
+		// No JSON-RPC payload: evaluate with an empty method so the
+		// default-deny policy applies instead of forwarding upstream.
+		return input, false
+	}
+
+	req, err := jsonrpc.Parse(body)
+	if err != nil {
+		// The proxy handler rejects malformed JSON-RPC with a parse error
+		// and never forwards it upstream.
+		return nil, true
+	}
+
+	input.Method = req.Method
+	input.ToolName = extractToolName(req)
+	return input, false
+}
+
+// readBody reads and restores the request body, enforcing the size limit.
+// It returns the body bytes and whether the read succeeded.
+func (m *Middleware) readBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	if r.Body == nil {
+		return nil, true
+	}
+
+	// Enforce the body size limit before io.ReadAll to prevent memory
+	// exhaustion from oversized payloads.
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
+
+	body, readErr := io.ReadAll(r.Body)
+	// Always restore whatever was read so downstream handlers can still
+	// process or correctly reject the request.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if readErr != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// extractToolName extracts the tool name from a "tools/call" request's params.
+// Returns an empty string for other methods or when params are malformed.
+func extractToolName(req *jsonrpc.Request) string {
+	if req.Method != toolCallMethod || len(req.Params) == 0 {
+		return ""
+	}
+
+	var params struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return ""
+	}
+	return params.Name
+}
+
+// writeForbidden writes a 403 response with a JSON error body.
+func writeForbidden(w http.ResponseWriter, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+
+	resp := struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}{
+		Error:   "forbidden",
+		Message: description,
+	}
+	//nolint:errcheck // best-effort write to response
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/policy/middleware_test.go
+++ b/internal/policy/middleware_test.go
@@ -1,0 +1,337 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/akaitigo/secure-mcp-gateway/internal/auth"
+)
+
+// mockEvaluator implements Evaluator for testing.
+type mockEvaluator struct {
+	err     error
+	decide  func(input *Input) bool
+	inputs  []*Input
+	allowed bool
+}
+
+func (m *mockEvaluator) Evaluate(_ context.Context, input *Input) (bool, error) {
+	m.inputs = append(m.inputs, input)
+	if m.err != nil {
+		return false, m.err
+	}
+	if m.decide != nil {
+		return m.decide(input), nil
+	}
+	return m.allowed, nil
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
+}
+
+// echoHandler records that it was reached and echoes the request body.
+func echoHandler(reached *bool, gotBody *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		if gotBody != nil {
+			body, _ := io.ReadAll(r.Body)
+			*gotBody = string(body)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}
+}
+
+// newToolCallRequest builds an authenticated JSON-RPC tools/call request.
+func newToolCallRequest(toolName string) *http.Request {
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + toolName + `"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	info := &auth.TokenInfo{
+		ClientID: "test-client",
+		Scopes:   []string{"tools:call"},
+	}
+	return req.WithContext(auth.WithTokenInfo(req.Context(), info))
+}
+
+func TestMiddleware_AllowedToolCall(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: true}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	var gotBody string
+	handler := mw.Handler(echoHandler(&reached, &gotBody))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newToolCallRequest("db-query"))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, reached, "downstream handler should be reached for allowed calls")
+
+	// Verify the policy input was built from token info and JSON-RPC body.
+	require.Len(t, mock.inputs, 1)
+	input := mock.inputs[0]
+	assert.Equal(t, "test-client", input.ClientID)
+	assert.Equal(t, []string{"tools:call"}, input.Scopes)
+	assert.Equal(t, "tools/call", input.Method)
+	assert.Equal(t, "db-query", input.ToolName)
+
+	// Verify the body was restored for the downstream handler.
+	assert.Contains(t, gotBody, `"db-query"`)
+}
+
+func TestMiddleware_DeniedToolCall(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newToolCallRequest("secret-tool"))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Contains(t, rec.Body.String(), "forbidden")
+	assert.Contains(t, rec.Body.String(), "denied by policy")
+	assert.False(t, reached, "downstream handler must not be reached for denied calls")
+}
+
+func TestMiddleware_EvaluatorError_FailClose(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{err: errors.New("OPA is down")}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newToolCallRequest("db-query"))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "policy evaluation unavailable")
+	assert.False(t, reached, "requests must be denied when the policy engine fails (fail-close)")
+}
+
+func TestMiddleware_UndefinedDecision_FailClose(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{err: ErrDecisionUndefined}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newToolCallRequest("db-query"))
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, reached)
+}
+
+func TestMiddleware_SelectiveDecision(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{
+		decide: func(input *Input) bool {
+			return input.ToolName == "allowed-tool"
+		},
+	}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	// Allowed tool passes.
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, newToolCallRequest("allowed-tool"))
+	assert.Equal(t, http.StatusOK, rec1.Code)
+
+	// Denied tool is rejected.
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, newToolCallRequest("forbidden-tool"))
+	assert.Equal(t, http.StatusForbidden, rec2.Code)
+}
+
+func TestMiddleware_SkipPath(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(
+		mock,
+		WithMiddlewareLogger(newTestLogger()),
+		WithSkipPaths("/health"),
+	)
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/health", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, reached)
+	assert.Empty(t, mock.inputs, "evaluator should not be called for skip paths")
+}
+
+func TestMiddleware_NonPOSTPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, reached, "non-POST requests pass through (no tool invocation)")
+	assert.Empty(t, mock.inputs)
+}
+
+func TestMiddleware_NonJSONContentTypePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("plain text"))
+	req.Header.Set("Content-Type", "text/plain")
+	handler.ServeHTTP(rec, req)
+
+	// The proxy handler rejects non-JSON POSTs itself; policy passes through.
+	assert.True(t, reached)
+	assert.Empty(t, mock.inputs)
+}
+
+func TestMiddleware_MalformedJSONRPCPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	var gotBody string
+	handler := mw.Handler(echoHandler(&reached, &gotBody))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{invalid-json`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+
+	// The proxy handler rejects malformed JSON-RPC with a parse error and
+	// never forwards it upstream; the body must be restored for it.
+	assert.True(t, reached)
+	assert.Equal(t, `{invalid-json`, gotBody)
+	assert.Empty(t, mock.inputs)
+}
+
+func TestMiddleware_EmptyBodyIsEvaluated(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+
+	// Empty-body POSTs must not bypass policy: they are evaluated with an
+	// empty method, which the default-deny policy rejects.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, reached)
+	require.Len(t, mock.inputs, 1)
+	assert.Empty(t, mock.inputs[0].Method)
+}
+
+func TestMiddleware_ToolNameOmittedForNonToolCall(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: true}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, mock.inputs, 1)
+	assert.Equal(t, "tools/list", mock.inputs[0].Method)
+	assert.Empty(t, mock.inputs[0].ToolName)
+}
+
+func TestMiddleware_MalformedParamsYieldsEmptyToolName(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":"not-an-object"}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+
+	// Malformed params yield an empty tool name, which the default-deny
+	// policy rejects.
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	require.Len(t, mock.inputs, 1)
+	assert.Empty(t, mock.inputs[0].ToolName)
+}
+
+func TestMiddleware_MissingTokenInfoYieldsEmptyClientID(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEvaluator{allowed: false}
+	mw := NewMiddleware(mock, WithMiddlewareLogger(newTestLogger()))
+
+	var reached bool
+	handler := mw.Handler(echoHandler(&reached, nil))
+
+	rec := httptest.NewRecorder()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"db-query"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	require.Len(t, mock.inputs, 1)
+	assert.Empty(t, mock.inputs[0].ClientID)
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,120 @@
+// Package policy provides OPA-based authorization for MCP tool invocations.
+// It evaluates tool-level allow/deny decisions against an external OPA server
+// and fails closed (deny) when the policy engine is unreachable or returns an
+// unexpected response.
+package policy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// decisionPath is the OPA Data API path of the boolean allow decision.
+// It corresponds to the `allow` rule in the `gateway.authz` Rego package
+// (see policies/default.rego).
+const decisionPath = "/v1/data/gateway/authz/allow"
+
+// ErrDecisionUndefined is returned when OPA responds without a result,
+// which means the decision document does not exist (e.g., the policy
+// bundle is not loaded). Callers must treat this as a deny (fail-close).
+var ErrDecisionUndefined = errors.New("policy decision undefined (is the policy loaded?)")
+
+// Input is the document sent to OPA for policy evaluation.
+type Input struct {
+	// ClientID is the authenticated OAuth2 client identifier.
+	ClientID string `json:"client_id"`
+	// Method is the JSON-RPC method being invoked (e.g., "tools/call").
+	Method string `json:"method"`
+	// ToolName is the MCP tool name for "tools/call" requests.
+	ToolName string `json:"tool_name,omitempty"`
+	// Scopes is the list of OAuth2 scopes granted to the client.
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// Evaluator defines the interface for policy evaluation.
+// This allows mocking in tests.
+type Evaluator interface {
+	Evaluate(ctx context.Context, input *Input) (bool, error)
+}
+
+// Client evaluates authorization policies against an OPA server
+// via the OPA REST Data API.
+type Client struct {
+	httpClient  *http.Client
+	decisionURL string
+}
+
+// NewClient creates a new OPA policy client for the given OPA base URL
+// (e.g., "http://localhost:8181").
+func NewClient(opaURL string, httpClient *http.Client) (*Client, error) {
+	if opaURL == "" {
+		return nil, errors.New("OPA URL is required")
+	}
+
+	if _, err := url.ParseRequestURI(opaURL); err != nil {
+		return nil, fmt.Errorf("invalid OPA URL: %w", err)
+	}
+
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 5 * time.Second,
+		}
+	}
+
+	return &Client{
+		decisionURL: strings.TrimRight(opaURL, "/") + decisionPath,
+		httpClient:  httpClient,
+	}, nil
+}
+
+// Evaluate queries OPA for an allow/deny decision on the given input.
+// It returns an error when OPA is unreachable, responds with a non-200
+// status, or the decision document is undefined. Callers must treat any
+// error as a deny (fail-close).
+func (c *Client) Evaluate(ctx context.Context, input *Input) (bool, error) {
+	payload := struct {
+		Input *Input `json:"input"`
+	}{Input: input}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal policy input: %w", err)
+	}
+
+	// decisionURL is derived from the trusted OPA_URL server configuration, not user input.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.decisionURL, bytes.NewReader(body)) //nolint:gosec // trusted config
+	if err != nil {
+		return false, fmt.Errorf("failed to create policy request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // trusted config (see above)
+	if err != nil {
+		return false, fmt.Errorf("policy evaluation request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("policy endpoint returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Result *bool `json:"result"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return false, fmt.Errorf("failed to decode policy response: %w", err)
+	}
+
+	if result.Result == nil {
+		return false, ErrDecisionUndefined
+	}
+
+	return *result.Result, nil
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,170 @@
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockOPA creates a mock OPA server that records the received input
+// and responds with the given raw JSON body and status code.
+func newMockOPA(t *testing.T, status int, responseBody string, capture *Input) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/data/gateway/authz/allow", r.URL.Path)
+
+		if capture != nil {
+			var payload struct {
+				Input *Input `json:"input"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+			require.NotNil(t, payload.Input)
+			*capture = *payload.Input
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+}
+
+func TestNewClient_EmptyURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClient("", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OPA URL is required")
+}
+
+func TestNewClient_InvalidURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClient("not-a-valid-url", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid OPA URL")
+}
+
+func TestClient_Evaluate_Allow(t *testing.T) {
+	t.Parallel()
+
+	var captured Input
+	opa := newMockOPA(t, http.StatusOK, `{"result": true}`, &captured)
+	defer opa.Close()
+
+	client, err := NewClient(opa.URL, nil)
+	require.NoError(t, err)
+
+	input := &Input{
+		ClientID: "test-client",
+		Scopes:   []string{"tools:read", "tools:call"},
+		Method:   "tools/call",
+		ToolName: "db-query",
+	}
+
+	allowed, err := client.Evaluate(context.Background(), input)
+	require.NoError(t, err)
+	assert.True(t, allowed)
+
+	// Verify the full input document was sent to OPA.
+	assert.Equal(t, "test-client", captured.ClientID)
+	assert.Equal(t, []string{"tools:read", "tools:call"}, captured.Scopes)
+	assert.Equal(t, "tools/call", captured.Method)
+	assert.Equal(t, "db-query", captured.ToolName)
+}
+
+func TestClient_Evaluate_Deny(t *testing.T) {
+	t.Parallel()
+
+	opa := newMockOPA(t, http.StatusOK, `{"result": false}`, nil)
+	defer opa.Close()
+
+	client, err := NewClient(opa.URL, nil)
+	require.NoError(t, err)
+
+	allowed, err := client.Evaluate(context.Background(), &Input{Method: "tools/call"})
+	require.NoError(t, err)
+	assert.False(t, allowed)
+}
+
+func TestClient_Evaluate_UndefinedDecision(t *testing.T) {
+	t.Parallel()
+
+	// OPA returns {} when the decision document does not exist
+	// (e.g., the policy is not loaded).
+	opa := newMockOPA(t, http.StatusOK, `{}`, nil)
+	defer opa.Close()
+
+	client, err := NewClient(opa.URL, nil)
+	require.NoError(t, err)
+
+	allowed, err := client.Evaluate(context.Background(), &Input{Method: "tools/list"})
+	require.ErrorIs(t, err, ErrDecisionUndefined)
+	assert.False(t, allowed)
+}
+
+func TestClient_Evaluate_Non200Status(t *testing.T) {
+	t.Parallel()
+
+	opa := newMockOPA(t, http.StatusInternalServerError, `{"error": "boom"}`, nil)
+	defer opa.Close()
+
+	client, err := NewClient(opa.URL, nil)
+	require.NoError(t, err)
+
+	allowed, err := client.Evaluate(context.Background(), &Input{Method: "tools/list"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+	assert.False(t, allowed)
+}
+
+func TestClient_Evaluate_InvalidJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	opa := newMockOPA(t, http.StatusOK, `not-json`, nil)
+	defer opa.Close()
+
+	client, err := NewClient(opa.URL, nil)
+	require.NoError(t, err)
+
+	allowed, err := client.Evaluate(context.Background(), &Input{Method: "tools/list"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to decode policy response")
+	assert.False(t, allowed)
+}
+
+func TestClient_Evaluate_ConnectionError(t *testing.T) {
+	t.Parallel()
+
+	// Create and immediately close the server to get an unreachable URL.
+	opa := newMockOPA(t, http.StatusOK, `{"result": true}`, nil)
+	opa.Close()
+
+	client, err := NewClient(opa.URL, nil)
+	require.NoError(t, err)
+
+	allowed, err := client.Evaluate(context.Background(), &Input{Method: "tools/list"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy evaluation request failed")
+	assert.False(t, allowed)
+}
+
+func TestClient_Evaluate_TrailingSlashURL(t *testing.T) {
+	t.Parallel()
+
+	opa := newMockOPA(t, http.StatusOK, `{"result": true}`, nil)
+	defer opa.Close()
+
+	client, err := NewClient(opa.URL+"/", nil)
+	require.NoError(t, err)
+
+	allowed, err := client.Evaluate(context.Background(), &Input{Method: "tools/list"})
+	require.NoError(t, err)
+	assert.True(t, allowed)
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -135,6 +135,50 @@ func NewMockHydraServerWithTokenValidation(expectedToken, clientID string) *http
 	}))
 }
 
+// PolicyDecisionFunc decides whether a policy input document is allowed.
+// The input map contains the fields sent by the gateway
+// (client_id, scopes, method, tool_name).
+type PolicyDecisionFunc func(input map[string]any) bool
+
+// NewMockOPAServer creates a mock OPA server that serves the
+// gateway/authz/allow decision using the given decision function.
+func NewMockOPAServer(decide PolicyDecisionFunc) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Validate the OPA Data API decision path.
+		if r.URL.Path != "/v1/data/gateway/authz/allow" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var payload struct {
+			Input map[string]any `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"result": decide(payload.Input),
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		}
+	}))
+}
+
+// NewAllowAllOPAServer creates a mock OPA server that allows every request.
+// Useful for tests that exercise flows other than policy enforcement.
+func NewAllowAllOPAServer() *httptest.Server {
+	return NewMockOPAServer(func(_ map[string]any) bool { return true })
+}
+
 // SetEnv sets an environment variable for the duration of the test.
 func SetEnv(t *testing.T, key, value string) {
 	t.Helper()

--- a/policies/data.json
+++ b/policies/data.json
@@ -1,0 +1,7 @@
+{
+  "gateway": {
+    "permissions": {
+      "demo-agent": ["mock-tool"]
+    }
+  }
+}

--- a/policies/default.rego
+++ b/policies/default.rego
@@ -1,17 +1,45 @@
+# Tool-level authorization policy for secure-mcp-gateway.
+#
+# The gateway queries POST /v1/data/gateway/authz/allow for every JSON-RPC
+# request with the following input document:
+#
+#   input.client_id  - authenticated OAuth2 client ID
+#   input.scopes     - granted OAuth2 scopes (optional)
+#   input.method     - JSON-RPC method (e.g. "tools/call")
+#   input.tool_name  - tool name for "tools/call" requests
+#
+# Client-to-tool grants live in the data document (policies/data.json):
+#
+#   data.gateway.permissions[client_id] = ["tool-a", "tool-b"]  # or ["*"]
+#
+# The gateway fails closed: if this decision is undefined or OPA is
+# unreachable, the request is denied.
 package gateway.authz
 
-# Default policy: deny all tool calls unless explicitly allowed.
-# This is the base policy for secure-mcp-gateway.
-# Production deployments should extend this with specific allow rules.
-
+# Fail-safe default: deny everything not explicitly allowed.
 default allow := false
 
-# Allow health check tools for any authenticated client.
-allow if {
-	input.tool_name == "health"
+# Protocol handshake and discovery methods allowed for any authenticated
+# client. Tool invocations are NOT in this set and require explicit grants.
+allowed_methods := {
+	"initialize",
+	"notifications/initialized",
+	"ping",
+	"tools/list",
 }
 
-# Allow tools/list for any authenticated client.
+allow if input.method in allowed_methods
+
+# Tool invocations: the client must be granted the specific tool name...
 allow if {
-	input.method == "tools/list"
+	input.method == "tools/call"
+	some tool in data.gateway.permissions[input.client_id]
+	tool == input.tool_name
+}
+
+# ...or the "*" wildcard, which grants every tool.
+allow if {
+	input.method == "tools/call"
+	some tool in data.gateway.permissions[input.client_id]
+	tool == "*"
 }

--- a/policies/default_test.rego
+++ b/policies/default_test.rego
@@ -1,0 +1,78 @@
+# Unit tests for the gateway.authz policy.
+# Run with: make policy-test
+package gateway.authz_test
+
+import data.gateway.authz
+
+test_default_deny_unknown_method if {
+	not authz.allow with input as {"client_id": "any-client", "method": "resources/read"}
+}
+
+test_empty_method_denied if {
+	not authz.allow with input as {"client_id": "any-client", "method": ""}
+}
+
+test_tools_list_allowed if {
+	authz.allow with input as {"client_id": "any-client", "method": "tools/list"}
+}
+
+test_initialize_allowed if {
+	authz.allow with input as {"client_id": "any-client", "method": "initialize"}
+}
+
+test_ping_allowed if {
+	authz.allow with input as {"client_id": "any-client", "method": "ping"}
+}
+
+test_tool_call_allowed_for_granted_client if {
+	authz.allow with input as {
+		"client_id": "demo-agent",
+		"method": "tools/call",
+		"tool_name": "mock-tool",
+	}
+		with data.gateway.permissions as {"demo-agent": ["mock-tool"]}
+}
+
+test_tool_call_denied_for_ungranted_tool if {
+	not authz.allow with input as {
+		"client_id": "demo-agent",
+		"method": "tools/call",
+		"tool_name": "secret-tool",
+	}
+		with data.gateway.permissions as {"demo-agent": ["mock-tool"]}
+}
+
+test_tool_call_denied_for_unknown_client if {
+	not authz.allow with input as {
+		"client_id": "stranger",
+		"method": "tools/call",
+		"tool_name": "mock-tool",
+	}
+		with data.gateway.permissions as {"demo-agent": ["mock-tool"]}
+}
+
+test_tool_call_denied_without_tool_name if {
+	not authz.allow with input as {
+		"client_id": "demo-agent",
+		"method": "tools/call",
+	}
+		with data.gateway.permissions as {"demo-agent": ["mock-tool"]}
+}
+
+test_wildcard_allows_any_tool if {
+	authz.allow with input as {
+		"client_id": "admin-agent",
+		"method": "tools/call",
+		"tool_name": "anything-at-all",
+	}
+		with data.gateway.permissions as {"admin-agent": ["*"]}
+}
+
+test_wildcard_scoped_to_client if {
+	not authz.allow with input as {
+		"client_id": "other-agent",
+		"method": "tools/call",
+		"tool_name": "anything-at-all",
+	}
+		with data.gateway.permissions as {"admin-agent": ["*"]}
+}

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -1,5 +1,6 @@
 // Package integration provides end-to-end tests for the secure-mcp-gateway.
-// These tests verify the full request flow: Proxy -> Token Verification -> Audit Logging.
+// These tests verify the full request flow:
+// Proxy -> Token Verification -> Policy Evaluation -> Audit Logging.
 package integration
 
 import (
@@ -21,11 +22,13 @@ import (
 
 	"github.com/akaitigo/secure-mcp-gateway/internal/audit"
 	"github.com/akaitigo/secure-mcp-gateway/internal/auth"
+	"github.com/akaitigo/secure-mcp-gateway/internal/policy"
 	"github.com/akaitigo/secure-mcp-gateway/internal/proxy"
 	"github.com/akaitigo/secure-mcp-gateway/internal/testutil"
 )
 
-// testGateway encapsulates a fully wired gateway (proxy + auth + audit) for integration tests.
+// testGateway encapsulates a fully wired gateway (proxy + auth + policy + audit)
+// for integration tests.
 type testGateway struct {
 	cleanup    func()
 	auditStore *audit.Store
@@ -33,11 +36,12 @@ type testGateway struct {
 }
 
 // newTestGateway creates a gateway with the full middleware chain:
-// RequestID -> Audit -> Auth -> Proxy -> Upstream MCP mock.
+// RequestID -> Audit -> Auth -> Policy -> Proxy -> Upstream MCP mock.
 func newTestGateway(
 	t *testing.T,
 	hydraServer *httptest.Server,
 	upstreamServer *httptest.Server,
+	opaServer *httptest.Server,
 ) *testGateway {
 	t.Helper()
 
@@ -59,10 +63,19 @@ func newTestGateway(
 		auth.WithMiddlewareLogger(slog.New(slog.NewJSONHandler(io.Discard, nil))),
 	)
 
+	// Set up policy middleware using mock OPA.
+	policyClient, err := policy.NewClient(opaServer.URL, nil)
+	require.NoError(t, err)
+	policyMiddleware := policy.NewMiddleware(
+		policyClient,
+		policy.WithSkipPaths("/health"),
+		policy.WithMiddlewareLogger(slog.New(slog.NewJSONHandler(io.Discard, nil))),
+	)
+
 	// Build proxy with full middleware chain.
 	// Middleware order (outermost to innermost):
-	//   RequestID -> Audit -> Auth -> Proxy handler
-	// Audit wraps Auth so that both ALLOW and DENY decisions are logged.
+	//   RequestID -> Audit -> Auth -> Policy -> Proxy handler
+	// Audit wraps Auth and Policy so that both ALLOW and DENY decisions are logged.
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	srv, err := proxy.New(
 		":0", upstreamServer.URL,
@@ -70,6 +83,7 @@ func newTestGateway(
 		proxy.WithMiddleware(audit.RequestIDMiddleware),
 		proxy.WithMiddleware(auditMiddleware.Handler),
 		proxy.WithMiddleware(authMiddleware.Handler),
+		proxy.WithMiddleware(policyMiddleware.Handler),
 	)
 	require.NoError(t, err)
 
@@ -88,6 +102,7 @@ func newTestGateway(
 		_ = srv.Shutdown(ctx)
 		hydraServer.Close()
 		upstreamServer.Close()
+		opaServer.Close()
 	}
 
 	return &testGateway{
@@ -129,7 +144,7 @@ func TestIntegration_ValidToken_AllowAndAuditLog(t *testing.T) {
 
 	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
 	upstream := newMockUpstream()
-	gw := newTestGateway(t, hydra, upstream)
+	gw := newTestGateway(t, hydra, upstream, testutil.NewAllowAllOPAServer())
 	defer gw.cleanup()
 
 	// Send a valid tools/call request with a valid Bearer token.
@@ -187,7 +202,7 @@ func TestIntegration_InvalidToken_DenyAndAuditLog(t *testing.T) {
 
 	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
 	upstream := newMockUpstream()
-	gw := newTestGateway(t, hydra, upstream)
+	gw := newTestGateway(t, hydra, upstream, testutil.NewAllowAllOPAServer())
 	defer gw.cleanup()
 
 	// Send a tools/call request with an INVALID Bearer token.
@@ -229,7 +244,7 @@ func TestIntegration_MissingToken_DenyAndAuditLog(t *testing.T) {
 
 	hydra := testutil.NewMockHydraServer(true, "any-client")
 	upstream := newMockUpstream()
-	gw := newTestGateway(t, hydra, upstream)
+	gw := newTestGateway(t, hydra, upstream, testutil.NewAllowAllOPAServer())
 	defer gw.cleanup()
 
 	// Send a request without any Authorization header.
@@ -262,7 +277,7 @@ func TestIntegration_HealthEndpoint_BypassesAuthAndAudit(t *testing.T) {
 
 	hydra := testutil.NewMockHydraServer(false, "")
 	upstream := newMockUpstream()
-	gw := newTestGateway(t, hydra, upstream)
+	gw := newTestGateway(t, hydra, upstream, testutil.NewAllowAllOPAServer())
 	defer gw.cleanup()
 
 	// Hit /health without any auth token.
@@ -297,7 +312,7 @@ func TestIntegration_MultipleRequests_AuditLogOrder(t *testing.T) {
 
 	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
 	upstream := newMockUpstream()
-	gw := newTestGateway(t, hydra, upstream)
+	gw := newTestGateway(t, hydra, upstream, testutil.NewAllowAllOPAServer())
 	defer gw.cleanup()
 
 	methods := []string{"tools/list", "tools/call", "resources/read"}
@@ -348,7 +363,7 @@ func TestIntegration_RequestID_Propagation(t *testing.T) {
 
 	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
 	upstream := newMockUpstream()
-	gw := newTestGateway(t, hydra, upstream)
+	gw := newTestGateway(t, hydra, upstream, testutil.NewAllowAllOPAServer())
 	defer gw.cleanup()
 
 	// Test 1: Auto-generated request ID.
@@ -389,4 +404,206 @@ func TestIntegration_RequestID_Propagation(t *testing.T) {
 	// Newest first: custom ID entry is entries[0].
 	assert.Equal(t, customID, entries[0].RequestID)
 	assert.NotEmpty(t, entries[1].RequestID)
+}
+
+// newToolPolicyOPA creates a mock OPA server that mirrors the default Rego
+// policy semantics: tools/list is always allowed, and tools/call is allowed
+// only for the given client_id and tool names.
+func newToolPolicyOPA(clientID string, allowedTools ...string) *httptest.Server {
+	allowed := make(map[string]bool, len(allowedTools))
+	for _, tool := range allowedTools {
+		allowed[tool] = true
+	}
+
+	return testutil.NewMockOPAServer(func(input map[string]any) bool {
+		method, _ := input["method"].(string)
+		if method == "tools/list" {
+			return true
+		}
+		if method != "tools/call" {
+			return false
+		}
+		client, _ := input["client_id"].(string)
+		tool, _ := input["tool_name"].(string)
+		return client == clientID && allowed[tool]
+	})
+}
+
+// TestIntegration_PolicyAllowedTool_ForwardedAndAuditAllow verifies that a
+// tool call permitted by policy is forwarded upstream and logged as ALLOW.
+func TestIntegration_PolicyAllowedTool_ForwardedAndAuditAllow(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validToken = "pol-ok1"
+		clientID   = "policy-agent"
+	)
+
+	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
+	upstream := newMockUpstream()
+	opa := newToolPolicyOPA(clientID, "db-query")
+	gw := newTestGateway(t, hydra, upstream, opa)
+	defer gw.cleanup()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"db-query"}}`
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, gw.proxyURL+"/",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+validToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rpcResp map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&rpcResp)
+	require.NoError(t, err)
+	result, ok := rpcResp["result"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "success", result["output"])
+
+	// Verify audit log recorded ALLOW.
+	entries, total := gw.auditStore.List(0, 10)
+	require.Equal(t, 1, total)
+	assert.Equal(t, audit.DecisionAllow, entries[0].Decision)
+	assert.Equal(t, clientID, entries[0].ClientID)
+}
+
+// TestIntegration_PolicyDeniedTool_403AndAuditDeny verifies that a tool call
+// rejected by policy returns 403, is never forwarded upstream, and is logged
+// as DENY with the authenticated client_id.
+func TestIntegration_PolicyDeniedTool_403AndAuditDeny(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validToken = "pol-ng1"
+		clientID   = "policy-agent"
+	)
+
+	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
+
+	// Upstream must never be reached for denied calls.
+	var upstreamCalled bool
+	upstream := testutil.NewMockMCPServer(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	opa := newToolPolicyOPA(clientID, "db-query")
+	gw := newTestGateway(t, hydra, upstream, opa)
+	defer gw.cleanup()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"secret-tool"}}`
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, gw.proxyURL+"/",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+validToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(respBody), "denied by policy")
+
+	assert.False(t, upstreamCalled, "denied requests must not reach upstream")
+
+	// Verify audit log recorded DENY with the authenticated client_id.
+	entries, total := gw.auditStore.List(0, 10)
+	require.Equal(t, 1, total)
+	assert.Equal(t, audit.DecisionDeny, entries[0].Decision)
+	assert.Equal(t, clientID, entries[0].ClientID)
+	assert.Equal(t, "tools/call", entries[0].ToolName)
+}
+
+// TestIntegration_OPAUnavailable_FailClose verifies that requests are denied
+// with 403 when the policy engine is unreachable (fail-close).
+func TestIntegration_OPAUnavailable_FailClose(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validToken = "fc-tok1"
+		clientID   = "fail-close-agent"
+	)
+
+	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
+
+	var upstreamCalled bool
+	upstream := testutil.NewMockMCPServer(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Close the OPA server immediately to simulate an outage. The URL stays
+	// valid but nothing is listening.
+	opa := testutil.NewAllowAllOPAServer()
+	opa.Close()
+	gw := newTestGateway(t, hydra, upstream, opa)
+	defer gw.cleanup()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"db-query"}}`
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, gw.proxyURL+"/",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+validToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(respBody), "policy evaluation unavailable")
+
+	assert.False(t, upstreamCalled, "requests must not reach upstream when OPA is down")
+
+	// Verify audit log recorded DENY.
+	entries, total := gw.auditStore.List(0, 10)
+	require.Equal(t, 1, total)
+	assert.Equal(t, audit.DecisionDeny, entries[0].Decision)
+}
+
+// TestIntegration_PolicyDiscoveryMethodAllowed verifies that discovery
+// methods (tools/list) pass policy without a tool grant.
+func TestIntegration_PolicyDiscoveryMethodAllowed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		validToken = "disc-01"
+		clientID   = "discovery-agent"
+	)
+
+	hydra := testutil.NewMockHydraServerWithTokenValidation(validToken, clientID)
+	upstream := newMockUpstream()
+	// No tool grants at all: only discovery methods are allowed.
+	opa := newToolPolicyOPA(clientID)
+	gw := newTestGateway(t, hydra, upstream, opa)
+	defer gw.cleanup()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, gw.proxyURL+"/",
+		strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+validToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
## 概要

ADR-003で先送りされていた「OPAによるツール粒度の認可ポリシー評価」(Phase 2) を実装する。認証済みクライアントであっても、ポリシーで許可されていないツールは呼び出せなくなる。

## 変更内容

### ポリシー評価 (internal/policy)
- OPAクライアント: `POST /v1/data/gateway/authz/allow` に `client_id` / `scopes` / `method` / `tool_name` を送信
- ポリシー評価ミドルウェア: ミドルウェアチェーンを **RequestID → Audit → Auth → Policy → Proxy** に拡張。拒否時は403を返し、監査ログにDENYを記録（client_id付き）
- **fail-close**: OPA到達不能・非200応答・decision未定義時はデフォルト拒否。fail-openにしない
- 空ボディPOSTもポリシー評価対象（デフォルト拒否）でバイパス不可。不正JSON-RPCはプロキシのparse errorで拒否（上流未転送）

### 設定
- `OPA_URL` 環境変数を必須として再導入（ADR-003の計画どおり）

### Regoポリシー (policies/)
- `default.rego`: デフォルト拒否 + ディスカバリ系メソッド許可 + クライアントID×ツール名の許可制御（PRDの「MVPでは単純なallow/denyポリシーに限定」に準拠）
- `data.json`: 許可リスト（`"*"` ワイルドカード対応）。ポリシー変更はゲートウェイ再デプロイ不要
- `default_test.rego`: Regoユニットテスト11件。`make policy-test` でCI実行

### docker-compose修正（既存バグ）
- OPAがlocalhostバインドでホストから到達不可 → `--addr=0.0.0.0:8181` を追加
- distrolessイメージにwgetが無くhealthcheckが常時unhealthy → `latest-debug` イメージ(busybox入り)に変更

### ドキュメント
- README: MVP注記を撤去し、ポリシー設定・fail-close・認可デモ手順を追記
- ADR-003: ステータスをSupersededに更新
- CHANGELOG: v1.1.0 追記

## テスト
- ユニットテスト: policyクライアント8件 + ミドルウェア12件 + config 2件追加
- 統合テスト: 許可ツール転送 / 拒否403+監査DENY / OPA停止時fail-close / ディスカバリ許可 の4件追加
- `go test -race ./...` 全パス、`golangci-lint run` 0 issues、`make check` / `make quality` / `buf lint` / `actionlint` 通過
- docker-compose実機検証: Hydra実トークンで tools/call 許可(200)・非許可(403)・OPA停止時fail-close(403)・監査ログALLOW/DENY記録を確認済み